### PR TITLE
Project cleanup: workspaces, headers, imports, oh my!

### DIFF
--- a/Examples/GridViewDemo/GridViewDemo.xcodeproj/project.pbxproj
+++ b/Examples/GridViewDemo/GridViewDemo.xcodeproj/project.pbxproj
@@ -16,26 +16,9 @@
 		1A530A4113DE962700E6C60B /* MainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1A530A3F13DE962700E6C60B /* MainWindow.xib */; };
 		1A530A4413DE962700E6C60B /* GridViewDemoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A530A4313DE962700E6C60B /* GridViewDemoViewController.m */; };
 		1A530A4713DE962700E6C60B /* GridViewDemoViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1A530A4513DE962700E6C60B /* GridViewDemoViewController.xib */; };
-		1A530A5813DE965900E6C60B /* libKKGridView.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A530A5513DE964D00E6C60B /* libKKGridView.a */; };
 		397E3D281406642500C3DEA3 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 397E3D271406642500C3DEA3 /* QuartzCore.framework */; };
+		FC026C01144C075700393CEB /* libKKGridView.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FC026C00144C075700393CEB /* libKKGridView.a */; };
 /* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		1A530A5413DE964D00E6C60B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1A530A4D13DE964D00E6C60B /* KKGridView.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 1A61BE0F13DCAF1F00AB4243;
-			remoteInfo = KKGridView;
-		};
-		1A530A5613DE965400E6C60B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1A530A4D13DE964D00E6C60B /* KKGridView.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 1A61BE0E13DCAF1F00AB4243;
-			remoteInfo = KKGridView;
-		};
-/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		1A530A2913DE962700E6C60B /* GridViewDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GridViewDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -52,8 +35,8 @@
 		1A530A4213DE962700E6C60B /* GridViewDemoViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GridViewDemoViewController.h; sourceTree = "<group>"; };
 		1A530A4313DE962700E6C60B /* GridViewDemoViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GridViewDemoViewController.m; sourceTree = "<group>"; };
 		1A530A4613DE962700E6C60B /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = en.lproj/GridViewDemoViewController.xib; sourceTree = "<group>"; };
-		1A530A4D13DE964D00E6C60B /* KKGridView.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = KKGridView.xcodeproj; path = ../../KKGridView.xcodeproj; sourceTree = "<group>"; };
 		397E3D271406642500C3DEA3 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		FC026C00144C075700393CEB /* libKKGridView.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libKKGridView.a; path = "../Debug-iphonesimulator/libKKGridView.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -61,8 +44,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FC026C01144C075700393CEB /* libKKGridView.a in Frameworks */,
 				397E3D281406642500C3DEA3 /* QuartzCore.framework in Frameworks */,
-				1A530A5813DE965900E6C60B /* libKKGridView.a in Frameworks */,
 				1A530A2E13DE962700E6C60B /* UIKit.framework in Frameworks */,
 				1A530A3013DE962700E6C60B /* Foundation.framework in Frameworks */,
 				1A530A3213DE962700E6C60B /* CoreGraphics.framework in Frameworks */,
@@ -77,7 +60,6 @@
 			children = (
 				1A530A3313DE962700E6C60B /* GridViewDemo */,
 				1A530A2C13DE962700E6C60B /* Frameworks */,
-				1A530A4D13DE964D00E6C60B /* KKGridView.xcodeproj */,
 				1A530A2A13DE962700E6C60B /* Products */,
 			);
 			indentWidth = 4;
@@ -95,6 +77,7 @@
 		1A530A2C13DE962700E6C60B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				FC026C00144C075700393CEB /* libKKGridView.a */,
 				1A530A3113DE962700E6C60B /* CoreGraphics.framework */,
 				1A530A2F13DE962700E6C60B /* Foundation.framework */,
 				397E3D271406642500C3DEA3 /* QuartzCore.framework */,
@@ -128,14 +111,6 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		1A530A4E13DE964D00E6C60B /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				1A530A5513DE964D00E6C60B /* libKKGridView.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -150,7 +125,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				1A530A5713DE965400E6C60B /* PBXTargetDependency */,
 			);
 			name = GridViewDemo;
 			productName = GridViewDemo;
@@ -176,28 +150,12 @@
 			mainGroup = 1A530A1E13DE962700E6C60B;
 			productRefGroup = 1A530A2A13DE962700E6C60B /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 1A530A4E13DE964D00E6C60B /* Products */;
-					ProjectRef = 1A530A4D13DE964D00E6C60B /* KKGridView.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				1A530A2813DE962700E6C60B /* GridViewDemo */,
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		1A530A5513DE964D00E6C60B /* libKKGridView.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libKKGridView.a;
-			remoteRef = 1A530A5413DE964D00E6C60B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		1A530A2713DE962700E6C60B /* Resources */ = {
@@ -224,14 +182,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		1A530A5713DE965400E6C60B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = KKGridView;
-			targetProxy = 1A530A5613DE965400E6C60B /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		1A530A3613DE962700E6C60B /* InfoPlist.strings */ = {
@@ -312,10 +262,8 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "GridViewDemo/GridViewDemo-Prefix.pch";
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
-				HEADER_SEARCH_PATHS = ../../KKGridView/;
 				INFOPLIST_FILE = "GridViewDemo/GridViewDemo-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
-				LIBRARY_SEARCH_PATHS = "../../build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				OTHER_LDFLAGS = (
 					"-lstdc++",
 					"-all_load",
@@ -336,10 +284,8 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "GridViewDemo/GridViewDemo-Prefix.pch";
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
-				HEADER_SEARCH_PATHS = ../../KKGridView/;
 				INFOPLIST_FILE = "GridViewDemo/GridViewDemo-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
-				LIBRARY_SEARCH_PATHS = "../../build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				OTHER_LDFLAGS = (
 					"-lstdc++",
 					"-all_load",

--- a/Examples/GridViewDemo/GridViewDemo.xcworkspace/contents.xcworkspacedata
+++ b/Examples/GridViewDemo/GridViewDemo.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:../../KKGridView.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "container:GridViewDemo.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Examples/GridViewDemo/GridViewDemo.xcworkspace/xcshareddata/xcschemes/GridViewDemo.xcscheme
+++ b/Examples/GridViewDemo/GridViewDemo.xcworkspace/xcshareddata/xcschemes/GridViewDemo.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1A61BE0E13DCAF1F00AB4243"
+               BuildableName = "libKKGridView.a"
+               BlueprintName = "KKGridView"
+               ReferencedContainer = "container:../../KKGridView.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1A530A2813DE962700E6C60B"
+               BuildableName = "GridViewDemo.app"
+               BlueprintName = "GridViewDemo"
+               ReferencedContainer = "container:GridViewDemo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1A530A2813DE962700E6C60B"
+            BuildableName = "GridViewDemo.app"
+            BlueprintName = "GridViewDemo"
+            ReferencedContainer = "container:GridViewDemo.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1A530A2813DE962700E6C60B"
+            BuildableName = "GridViewDemo.app"
+            BlueprintName = "GridViewDemo"
+            ReferencedContainer = "container:GridViewDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1A530A2813DE962700E6C60B"
+            BuildableName = "GridViewDemo.app"
+            BlueprintName = "GridViewDemo"
+            ReferencedContainer = "container:GridViewDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/GridViewDemo/GridViewDemo.xcworkspace/xcshareddata/xcschemes/KKGridView.xcscheme
+++ b/Examples/GridViewDemo/GridViewDemo.xcworkspace/xcshareddata/xcschemes/KKGridView.xcscheme
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1A61BE0E13DCAF1F00AB4243"
+               BuildableName = "libKKGridView.a"
+               BlueprintName = "KKGridView"
+               ReferencedContainer = "container:../../KKGridView.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/GridViewDemo/GridViewDemo/GridViewDemo-Prefix.pch
+++ b/Examples/GridViewDemo/GridViewDemo/GridViewDemo-Prefix.pch
@@ -11,5 +11,5 @@
 #ifdef __OBJC__
     #import <UIKit/UIKit.h>
     #import <Foundation/Foundation.h>
-    #import "KKGridView.h"
+    #import <KKGridView/KKGridView.h>
 #endif

--- a/Examples/GridViewDemo/GridViewDemo/GridViewDemoViewController.m
+++ b/Examples/GridViewDemo/GridViewDemo/GridViewDemoViewController.m
@@ -8,8 +8,9 @@
 
 #import "GridViewDemoViewController.h"
 #import <QuartzCore/QuartzCore.h>
-#import "KKGridViewCell.h"
-#import "KKIndexPath.h"
+#import <KKGridView/KKGridView.h>
+#import <KKGridView/KKGridViewCell.h>
+#import <KKGridView/KKIndexPath.h>
 
 static const NSUInteger kNumSection = 40;
 

--- a/KKGridView.xcodeproj/project.pbxproj
+++ b/KKGridView.xcodeproj/project.pbxproj
@@ -19,7 +19,7 @@
 		1A3F1B7113E34A62006747A3 /* KKGridViewUpdateStack.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A3F1B6F13E34A61006747A3 /* KKGridViewUpdateStack.m */; };
 		1A3F1B7413E34CF8006747A3 /* KKGridViewUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A3F1B7213E34CF8006747A3 /* KKGridViewUpdate.h */; };
 		1A3F1B7513E34CF8006747A3 /* KKGridViewUpdate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A3F1B7313E34CF8006747A3 /* KKGridViewUpdate.m */; };
-		1A5F356713DD02CD00A38A3E /* Definitions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A5F356613DD02CD00A38A3E /* Definitions.h */; };
+		1A5F356713DD02CD00A38A3E /* Definitions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A5F356613DD02CD00A38A3E /* Definitions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1A61BE1313DCAF1F00AB4243 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A61BE1213DCAF1F00AB4243 /* Foundation.framework */; };
 		1AD5397A13DF7A060071EFDC /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AD5397913DF7A060071EFDC /* CoreFoundation.framework */; };
 		1AD5397C13DF7E690071EFDC /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AD5397B13DF7E690071EFDC /* QuartzCore.framework */; };
@@ -257,11 +257,12 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "KKGridView/KKGridView-Prefix.pch";
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				INSTALL_PATH = "/../BuildProductsPath/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/";
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "include/$(PROJECT_NAME)";
 				RUN_CLANG_STATIC_ANALYZER = YES;
-				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
@@ -275,10 +276,11 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "KKGridView/KKGridView-Prefix.pch";
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				INSTALL_PATH = "/../BuildProductsPath/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/";
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
+				PUBLIC_HEADERS_FOLDER_PATH = "include/$(PROJECT_NAME)";
 			};
 			name = Release;
 		};

--- a/KKGridView/KKGridView-Prefix.pch
+++ b/KKGridView/KKGridView-Prefix.pch
@@ -8,5 +8,5 @@
     #import <Foundation/Foundation.h>
     #import <QuartzCore/QuartzCore.h>
     #import <UIKit/UIKit.h>
-    #import "Definitions.h"
+    #import <KKGridView/Definitions.h>
 #endif

--- a/KKGridView/KKGridView.h
+++ b/KKGridView/KKGridView.h
@@ -8,6 +8,7 @@
 
 #import <KKGridView/KKGridViewCell.h>
 #import <KKGridView/KKIndexPath.h>
+#import <KKGridView/Definitions.h>
 
 typedef enum {
     KKGridViewScrollPositionNone,        

--- a/KKGridView/KKGridView.h
+++ b/KKGridView/KKGridView.h
@@ -9,7 +9,6 @@
 #import "KKGridViewCell.h"
 #import "Definitions.h"
 #import "KKIndexPath.h"
-#import "KKGridViewViewInfo.h"
 
 typedef enum {
     KKGridViewScrollPositionNone,        

--- a/KKGridView/KKGridView.h
+++ b/KKGridView/KKGridView.h
@@ -7,7 +7,6 @@
 //
 
 #import "KKGridViewCell.h"
-#import "Definitions.h"
 #import "KKIndexPath.h"
 
 typedef enum {

--- a/KKGridView/KKGridView.h
+++ b/KKGridView/KKGridView.h
@@ -6,8 +6,8 @@
 //  Copyright 2011 Giulio Petek, Jonathan Sterling, and Kolin Krewinkel. All rights reserved.
 //
 
-#import "KKGridViewCell.h"
-#import "KKIndexPath.h"
+#import <KKGridView/KKGridViewCell.h>
+#import <KKGridView/KKIndexPath.h>
 
 typedef enum {
     KKGridViewScrollPositionNone,        

--- a/KKGridView/KKGridView.mm
+++ b/KKGridView/KKGridView.mm
@@ -6,12 +6,12 @@
 //  Copyright 2011 Giulio Petek, Jonathan Sterling, and Kolin Krewinkel. All rights reserved.
 //
 
-#import "KKGridView.h"
-#import "KKGridViewViewInfo.h"
-#import "KKIndexPath.h"
-#import "KKGridViewUpdate.h"
-#import "KKGridViewUpdateStack.h"
-#import "KKGridViewCell.h"
+#import <KKGridView/KKGridView.h>
+#import <KKGridView/KKGridViewViewInfo.h>
+#import <KKGridView/KKIndexPath.h>
+#import <KKGridView/KKGridViewUpdate.h>
+#import <KKGridView/KKGridViewUpdateStack.h>
+#import <KKGridView/KKGridViewCell.h>
 #import <map>
 #import <vector>
 

--- a/KKGridView/KKGridViewCell.h
+++ b/KKGridView/KKGridViewCell.h
@@ -6,8 +6,6 @@
 //  Copyright 2011 Giulio Petek, Jonathan Sterling, and Kolin Krewinkel. All rights reserved.
 //
 
-#import "Definitions.h"
-
 @class KKGridView;
 @class KKIndexPath;
 

--- a/KKGridView/KKGridViewCell.m
+++ b/KKGridView/KKGridViewCell.m
@@ -6,8 +6,8 @@
 //  Copyright 2011 Giulio Petek, Jonathan Sterling, and Kolin Krewinkel. All rights reserved.
 //
 
-#import "KKGridViewCell.h"
-#import "KKGridView.h"
+#import <KKGridView/KKGridViewCell.h>
+#import <KKGridView/KKGridView.h>
 
 @implementation KKGridViewCell
 

--- a/KKGridView/KKGridViewUpdate.h
+++ b/KKGridView/KKGridViewUpdate.h
@@ -6,8 +6,8 @@
 //  Copyright 2011 Giulio Petek, Jonathan Sterling, and Kolin Krewinkel. All rights reserved.
 //
 
-#import "KKIndexPath.h"
-#import "KKGridView.h"
+#import <KKGridView/KKIndexPath.h>
+#import <KKGridView/KKGridView.h>
 
 typedef enum {
     KKGridViewUpdateTypeItemInsert,

--- a/KKGridView/KKGridViewUpdate.m
+++ b/KKGridView/KKGridViewUpdate.m
@@ -6,7 +6,7 @@
 //  Copyright 2011 Giulio Petek, Jonathan Sterling, and Kolin Krewinkel. All rights reserved.
 //
 
-#import "KKGridViewUpdate.h"
+#import <KKGridView/KKGridViewUpdate.h>
 
 @implementation KKGridViewUpdate
 

--- a/KKGridView/KKGridViewUpdateStack.h
+++ b/KKGridView/KKGridViewUpdateStack.h
@@ -6,7 +6,7 @@
 //  Copyright 2011 Giulio Petek, Jonathan Sterling, and Kolin Krewinkel. All rights reserved.
 //
 
-#import "KKGridView.h"
+#import <KKGridView/KKGridView.h>
 
 @class KKGridViewUpdate;
 @interface KKGridViewUpdateStack : NSObject

--- a/KKGridView/KKGridViewUpdateStack.m
+++ b/KKGridView/KKGridViewUpdateStack.m
@@ -6,8 +6,8 @@
 //  Copyright 2011 Giulio Petek, Jonathan Sterling, and Kolin Krewinkel. All rights reserved.
 //
 
-#import "KKGridViewUpdateStack.h"
-#import "KKGridViewUpdate.h"
+#import <KKGridView/KKGridViewUpdateStack.h>
+#import <KKGridView/KKGridViewUpdate.h>
 
 @interface KKGridViewUpdateStack ()
 

--- a/KKGridView/KKGridViewViewInfo.m
+++ b/KKGridView/KKGridViewViewInfo.m
@@ -6,7 +6,7 @@
 //  Copyright 2011 Giulio Petek, Jonathan Sterling, and Kolin Krewinkel. All rights reserved.
 //
 
-#import "KKGridViewViewInfo.h"
+#import <KKGridView/KKGridViewViewInfo.h>
 
 @implementation KKGridViewViewInfo
 

--- a/KKGridView/KKIndexPath.m
+++ b/KKGridView/KKIndexPath.m
@@ -6,7 +6,7 @@
 //  Copyright 2011 Giulio Petek, Jonathan Sterling, and Kolin Krewinkel. All rights reserved.
 //
 
-#import "KKIndexPath.h"
+#import <KKGridView/KKIndexPath.h>
 
 @implementation KKIndexPath
 


### PR DESCRIPTION
Lo! I think I've gotten this to a point where the project/workspace integration doesn't drive me insane. A brief rundown:
1. `KKGridView` project: new settings for public headers dir and installation dir (tweaked to make archive build work)
2. `GridViewDemo` project (and any other host project): you don't have to specify your header search paths anymore. Not even joking.
3. Now, you import stuff as if it were a framework: `#import <KKGridView/KKGridView.h>`.
4. Made `Definitions.h` public, since it's getting used in other exported headers.

This works great on my end running on the latest public release of Xcode 4.2.
