### PR TITLE
Fixed crash when there's no header or footer views

### DIFF
--- a/Examples/GridViewDemo/GridViewDemo/GridViewDemoViewController.m
+++ b/Examples/GridViewDemo/GridViewDemo/GridViewDemoViewController.m
@@ -99,7 +99,7 @@ static const NSUInteger kNumSection = 40;
     }];
     
     [self.gridView setNumberOfSectionsBlock:^(KKGridView *gridView) {
-        return kNumSection; 
+        return kNumSection;
     }];
     
     

--- a/KKGridView/KKGridView.h
+++ b/KKGridView/KKGridView.h
@@ -102,5 +102,8 @@ typedef enum {
 - (void)selectRowsAtIndexPaths:(NSArray *)indexPaths animated:(BOOL)animated;
 - (void)deselectRowsAtIndexPaths:(NSArray *)indexPaths animated:(BOOL)animated;
 
+- (KKIndexPath*) indexPathForSelectedCell;
+- (NSArray *)indexPathsForSelectedCells;
+
 @end
 

--- a/KKGridView/KKGridView.mm
+++ b/KKGridView/KKGridView.mm
@@ -1152,6 +1152,18 @@
         [UIView commitAnimations];
 }
 
+- (KKIndexPath*) indexPathForSelectedCell {
+    if (!_allowsMultipleSelection) {
+        return [_selectedIndexPaths anyObject];
+    } else {
+        return nil;
+    }
+}
+
+- (NSArray *)indexPathsForSelectedCells {
+    return [_selectedIndexPaths allObjects];
+}
+
 #pragma mark - Internal Selection Methods
 
 - (void)_selectItemAtIndexPath:(KKIndexPath *)indexPath

--- a/KKGridView/KKGridView.mm
+++ b/KKGridView/KKGridView.mm
@@ -478,14 +478,17 @@
             
             for (NSUInteger section = 0; section < _numberOfSections; section++) {
                 KKGridViewHeader *header = [_headerViews objectAtIndex:section];
+                if (header) {
+                    CGFloat headerPosition = [self _sectionHeightsCombinedUpToSection:section] + _gridHeaderView.frame.size.height;
+                    [self _configureAuxiliaryView:header inSection:section withStickPoint:headerPosition height:_headerHeights[section]];
+                }
+                
                 KKGridViewFooter *footer = [_footerViews objectAtIndex:section];
-                
-                CGFloat headerPosition = [self _sectionHeightsCombinedUpToSection:section] + _gridHeaderView.frame.size.height;
-                CGFloat footerHeight = _footerHeights[section];
-                CGFloat footerPosition = [self _sectionHeightsCombinedUpToSection:section+1] + _gridHeaderView.frame.size.height - footerHeight;
-                
-                [self _configureAuxiliaryView:header inSection:section withStickPoint:headerPosition height:_headerHeights[section]];
-                [self _configureAuxiliaryView:footer inSection:section withStickPoint:footerPosition height:footerHeight];
+                if (footer) {
+                    CGFloat footerHeight = _footerHeights[section];
+                    CGFloat footerPosition = [self _sectionHeightsCombinedUpToSection:section+1] + _gridHeaderView.frame.size.height - footerHeight;
+                    [self _configureAuxiliaryView:footer inSection:section withStickPoint:footerPosition height:footerHeight];
+                }
             }
         } completion:nil];
     }

--- a/KKGridView/KKGridView.mm
+++ b/KKGridView/KKGridView.mm
@@ -411,7 +411,8 @@
                     cell.frame = [self rectForCellAtIndexPath:update.destinationPath];
                 }];
                 [self _incrementCellsAtIndexPath:update.destinationPath toIndexPath:[self _lastIndexPathForSection:indexPath.section] byAmount:1 amountNegative:NO];
-                [self _incrementCellsAtIndexPath:update.indexPath toIndexPath:[self _lastIndexPathForSection:indexPath.section] byAmount:1 amountNegative:NO];
+                //                [self _incrementCellsAtIndexPath:update.indexPath toIndexPath:[self _lastIndexPathForSection:indexPath.section] byAmount:1 amountNegative:NO];
+                [_updateStack removeUpdate:update];
             }
             
             NSMutableSet *replacementSet = [[NSMutableSet alloc] initWithCapacity:[_selectedIndexPaths count]];
@@ -899,7 +900,6 @@
     _staggerForInsertion = YES;
     _markedForDisplay = YES;
     [self _layoutGridView];
-//    [self _performRemainingUpdatesModelOnly];
 }
 
 - (void)reloadItemsAtIndexPaths:(NSArray *)indexPaths

--- a/KKGridView/KKIndexPath.h
+++ b/KKGridView/KKIndexPath.h
@@ -14,11 +14,13 @@
 - (id)initWithNSIndexPath:(NSIndexPath *)indexPath;
 + (id)indexPathWithNSIndexPath:(NSIndexPath *)indexPath;
 
-- (NSIndexPath*) nsIndexPath;
+- (NSIndexPath *)NSIndexPath;
+
+#pragmamark - NSArray
+
+- (NSComparisonResult)compare:(id)other;
 
 @property (nonatomic, readwrite) NSUInteger section;
 @property (nonatomic, readwrite) NSUInteger index;
-
-- (NSComparisonResult)compare:(id)other;
 
 @end

--- a/KKGridView/KKIndexPath.h
+++ b/KKGridView/KKIndexPath.h
@@ -16,7 +16,7 @@
 
 - (NSIndexPath *)NSIndexPath;
 
-#pragmamark - NSArray
+#pragma mark - NSArray
 
 - (NSComparisonResult)compare:(id)other;
 

--- a/KKGridView/KKIndexPath.m
+++ b/KKGridView/KKIndexPath.m
@@ -73,13 +73,15 @@
     return (indexPath.index == self.index && indexPath.section == self.section);
 }
 
-- (NSUInteger)hash {
+- (NSUInteger)hash
+{
     return _section + 7 * _index;
 }
 
 #pragma mark - NSCopying
 
-- (id)copyWithZone:(NSZone *)zone {
+- (id)copyWithZone:(NSZone *)zone
+{
     return [[[self class] alloc] initWithIndex:_index section:_section];
 }
 
@@ -90,7 +92,7 @@
 
 #pragma mark - KKIndexPath to NSIndexPath
 
-- (NSIndexPath*) nsIndexPath {
+- (NSIndexPath *)NSIndexPath {
     return [NSIndexPath indexPathForRow:self.index inSection:self.section];
 }
 


### PR DESCRIPTION
Fixed a crash when calling the animation methods for inserting & deleting cells, when no header or footer views were present. I've also added

``` objc
- (KKIndexPath*) indexPathForSelectedCell;
- (NSArray *)indexPathsForSelectedCells;
```

to KKGridView
