### PR TITLE
Add CocoaPods podspec

### DIFF
--- a/KKGridView.podspec
+++ b/KKGridView.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name     = 'KKGridView'
+  s.version  = '0.0.1'
+  s.license  = 'MIT'
+  s.platform = :ios
+  s.summary  = 'A high-performance iOS grid view.'
+  s.homepage = 'https://github.com/kolinkrewinkel/KKGridView'
+  s.authors  = { 'Kolin Krewinkel'   => 'kolin.krewinkel@me.com',
+                 'Giulio Petek'      => 'gi-lo@touch-mania.com',
+                 'Jonathan Sterling' => 'jonsterling@me.com',
+                 'Kyle Hickinson'    => 'kyle.hickinson@gmail.com',
+                 'Matthias Tretter'  => 'matthias.tretter@gmail.com',
+                 'Peter Steinberger' => 'me@petersteinberger.com' }
+
+  s.source   = { :git => 'https://github.com/kolinkrewinkel/KKGridView.git', :tag => '0.0.1' }
+
+  s.source_files = 'KKGridView'
+  s.clean_paths  = 'Examples', 'KKGridView.xcodeproj', 'Resources'
+  s.library      = 'stdc++'
+  s.framework    = 'QuartzCore'
+  s.requires_arc = true
+end


### PR DESCRIPTION
I recently added KKGridView to the [CocoaPods](https://github.com/CocoaPods/CocoaPods) package manager.

Since KKGridView doesn't currently have a discreet version, I treated [the current commit](https://github.com/CocoaPods/Specs/blob/master/KKGridView/0.0.1/KKGridView.podspec#L16) as the 0.0.1 release. Would it be possible to have your most recent commit tagged as 0.0.1 (or whatever version you feel comfortable with)? This will help greatly in dependency resolution.

Finally, this pull request adds the pod spec to the repo as well. Adding this will allow users to install an unreleased version directly from your repo. It also allows you to more easily keep the spec up-to-date with any possible changes, instead of having to remember it all when releasing a new version.

Thanks!
