### PR TITLE
Unblocks

### DIFF
--- a/Examples/GridViewDemo/GridViewDemo/GridViewDemoViewController.h
+++ b/Examples/GridViewDemo/GridViewDemo/GridViewDemoViewController.h
@@ -8,7 +8,7 @@
 
 #import <KKGridView/KKGridViewController.h>
 
-@interface GridViewDemoViewController : KKGridViewController <UISearchBarDelegate,KKGridViewDataSource>
+@interface GridViewDemoViewController : KKGridViewController <UISearchBarDelegate>
 
 @property (nonatomic) NSUInteger firstSectionCount;
 @property (nonatomic, strong) NSMutableArray *footerViews;

--- a/Examples/GridViewDemo/GridViewDemo/GridViewDemoViewController.h
+++ b/Examples/GridViewDemo/GridViewDemo/GridViewDemoViewController.h
@@ -8,7 +8,7 @@
 
 #import <KKGridView/KKGridViewController.h>
 
-@interface GridViewDemoViewController : KKGridViewController <UISearchBarDelegate>
+@interface GridViewDemoViewController : KKGridViewController <UISearchBarDelegate,KKGridViewDataSource>
 
 @property (nonatomic) NSUInteger firstSectionCount;
 @property (nonatomic, strong) NSMutableArray *footerViews;

--- a/Examples/GridViewDemo/GridViewDemo/GridViewDemoViewController.m
+++ b/Examples/GridViewDemo/GridViewDemo/GridViewDemoViewController.m
@@ -64,8 +64,6 @@ static const NSUInteger kNumSection = 40;
     UIBarButtonItem *move = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemOrganize target:self action:@selector(moveItems:)];
     
     self.toolbarItems = [NSArray arrayWithObjects:add, spacer, remove, spacer, move, spacer, multiple, nil];
-    
-    self.gridView.dataSource = self;
 }
 
 #pragma mark - KKGridViewDataSource

--- a/Examples/GridViewDemo/GridViewDemo/GridViewDemoViewController.m
+++ b/Examples/GridViewDemo/GridViewDemo/GridViewDemoViewController.m
@@ -14,12 +14,6 @@
 
 static const NSUInteger kNumSection = 40;
 
-@interface GridViewDemoViewController ()
-
-- (void)_setupGridView;
-
-@end
-
 @implementation GridViewDemoViewController
 @synthesize firstSectionCount = _firstSectionCount;
 @synthesize footerViews = _footerViews;
@@ -71,61 +65,71 @@ static const NSUInteger kNumSection = 40;
     
     self.toolbarItems = [NSArray arrayWithObjects:add, spacer, remove, spacer, move, spacer, multiple, nil];
     
-    [self _setupGridView];
+    self.gridView.dataSource = self;
 }
 
-- (void)_setupGridView
+#pragma mark - KKGridViewDataSource
+
+- (NSUInteger)numberOfSectionsInGridView:(KKGridView *)gridView
 {
-    __block typeof(self) selfRef = self;
-    
-    [self.gridView setNumberOfItemsInSectionBlock:^(KKGridView *gridView, NSUInteger section) {
-        switch (section) {
-            case 0:
-                return selfRef.firstSectionCount;
-                break;
-            case 1:
-                return 15;
-                break;
-            case 2:
-                return 10;
-                break;
-            case 3:
-                return 5;
-                break;
-            default:
-                return (section % 2) ? 4 : 7;
-                break;
-        }
-    }];
-    [self.gridView setNumberOfSectionsBlock:^(KKGridView *gridView) {
-        return kNumSection;
-    }];
-    [self.gridView setHeightForFooterInSectionBlock:^(KKGridView *gridView, NSUInteger section) {
-        return 25.f;
-    }];
-    [self.gridView setHeightForHeaderInSectionBlock:^(KKGridView *gridView, NSUInteger section) {
-        return 25.f;
-    }];
-    [self.gridView setCellBlock:^(KKGridView *gridView, KKIndexPath *indexPath) {
-        KKGridViewCell *cell = [KKGridViewCell cellForGridView:gridView];
-        if (indexPath.index % 2) {
-            cell.accessoryType = KKGridViewCellAccessoryTypeUnread;
-        } else {
-            cell.accessoryType = KKGridViewCellAccessoryTypeReadPartial;
-        }
-        cell.accessoryPosition = KKGridViewCellAccessoryPositionTopLeft;
-        cell.contentView.backgroundColor = [UIColor lightGrayColor];
-        
-        return cell; 
-    }];
-    [self.gridView setViewForFooterInSectionBlock:^(KKGridView *gridView, NSUInteger section) {
-        return [selfRef.footerViews objectAtIndex:section]; 
-    }];
-    [self.gridView setViewForHeaderInSectionBlock:^(KKGridView *gridView, NSUInteger section) {
-        return [selfRef.headerViews objectAtIndex:section];
-    }];
-    
+    return kNumSection;
 }
+
+- (NSUInteger)gridView:(KKGridView *)gridView numberOfItemsInSection:(NSUInteger)section
+{
+    switch (section) {
+        case 0:
+            return self.firstSectionCount;
+            break;
+        case 1:
+            return 15;
+            break;
+        case 2:
+            return 10;
+            break;
+        case 3:
+            return 5;
+            break;
+        default:
+            return (section % 2) ? 4 : 7;
+            break;
+    }
+}
+
+- (KKGridViewCell *)gridView:(KKGridView *)gridView cellForItemAtIndexPath:(KKIndexPath *)indexPath
+{
+    KKGridViewCell *cell = [KKGridViewCell cellForGridView:gridView];
+    if (indexPath.index % 2) {
+        cell.accessoryType = KKGridViewCellAccessoryTypeUnread;
+    } else {
+        cell.accessoryType = KKGridViewCellAccessoryTypeReadPartial;
+    }
+    cell.accessoryPosition = KKGridViewCellAccessoryPositionTopLeft;
+    cell.contentView.backgroundColor = [UIColor lightGrayColor];
+    
+    return cell; 
+}
+
+- (CGFloat)gridView:(KKGridView *)gridView heightForHeaderInSection:(NSUInteger)section
+{
+    return 25.f;
+}
+
+- (CGFloat)gridView:(KKGridView *)gridView heightForFooterInSection:(NSUInteger)section
+{
+    return 25.f;
+}
+
+- (UIView *)gridView:(KKGridView *)gridView viewForHeaderInSection:(NSUInteger)section
+{
+    return [self.headerViews objectAtIndex:section];
+}
+
+- (UIView *)gridView:(KKGridView *)gridView viewForFooterInSection:(NSUInteger)section
+{
+    return [self.footerViews objectAtIndex:section];
+}
+
 
 #pragma mark - UISearchBarDelegate
 

--- a/KKGridView.xcodeproj/project.pbxproj
+++ b/KKGridView.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		1A72A9761453AE42002546F8 /* KKGridViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A72A9741453AE42002546F8 /* KKGridViewController.m */; };
 		1AD5397A13DF7A060071EFDC /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AD5397913DF7A060071EFDC /* CoreFoundation.framework */; };
 		1AD5397C13DF7E690071EFDC /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AD5397B13DF7E690071EFDC /* QuartzCore.framework */; };
+		FC368B40149B483900B92E57 /* KKBlocksDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = FC368B3E149B483900B92E57 /* KKBlocksDelegate.h */; };
+		FC368B41149B483900B92E57 /* KKBlocksDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FC368B3F149B483900B92E57 /* KKBlocksDelegate.m */; };
 		FC53DF8313E629FE000767B1 /* KKGridViewViewInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = FC53DF8113E629FE000767B1 /* KKGridViewViewInfo.h */; };
 		FC53DF8413E629FE000767B1 /* KKGridViewViewInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = FC53DF8213E629FE000767B1 /* KKGridViewViewInfo.m */; };
 /* End PBXBuildFile section */
@@ -53,6 +55,8 @@
 		1A7DF7081454E543000372DA /* Resources-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Resources-Prefix.pch"; sourceTree = "<group>"; };
 		1AD5397913DF7A060071EFDC /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		1AD5397B13DF7E690071EFDC /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		FC368B3E149B483900B92E57 /* KKBlocksDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KKBlocksDelegate.h; sourceTree = "<group>"; };
+		FC368B3F149B483900B92E57 /* KKBlocksDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KKBlocksDelegate.m; sourceTree = "<group>"; };
 		FC53DF8113E629FE000767B1 /* KKGridViewViewInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KKGridViewViewInfo.h; sourceTree = "<group>"; };
 		FC53DF8213E629FE000767B1 /* KKGridViewViewInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KKGridViewViewInfo.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -122,6 +126,8 @@
 				1A0BEC7513DDF862003C2632 /* KKIndexPath.m */,
 				1A72A9731453AE42002546F8 /* KKGridViewController.h */,
 				1A72A9741453AE42002546F8 /* KKGridViewController.m */,
+				FC368B3E149B483900B92E57 /* KKBlocksDelegate.h */,
+				FC368B3F149B483900B92E57 /* KKBlocksDelegate.m */,
 				1A61BE1513DCAF1F00AB4243 /* Supporting Files */,
 			);
 			path = KKGridView;
@@ -169,6 +175,7 @@
 				1A3F1B7413E34CF8006747A3 /* KKGridViewUpdate.h in Headers */,
 				1A3F1B7013E34A62006747A3 /* KKGridViewUpdateStack.h in Headers */,
 				FC53DF8313E629FE000767B1 /* KKGridViewViewInfo.h in Headers */,
+				FC368B40149B483900B92E57 /* KKBlocksDelegate.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -230,6 +237,7 @@
 				1A3F1B7513E34CF8006747A3 /* KKGridViewUpdate.m in Sources */,
 				FC53DF8413E629FE000767B1 /* KKGridViewViewInfo.m in Sources */,
 				1A72A9761453AE42002546F8 /* KKGridViewController.m in Sources */,
+				FC368B41149B483900B92E57 /* KKBlocksDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/KKGridView.xcodeproj/project.pbxproj
+++ b/KKGridView.xcodeproj/project.pbxproj
@@ -35,7 +35,7 @@
 		1A32AD7F13DCDF1D00E8CC7C /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		1A32AD8013DCDF1D00E8CC7C /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		1A32AD8313DCDFB200E8CC7C /* KKGridView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KKGridView.h; sourceTree = "<group>"; };
-		1A32AD8413DCDFB200E8CC7C /* KKGridView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KKGridView.m; sourceTree = "<group>"; };
+		1A32AD8413DCDFB200E8CC7C /* KKGridView.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = KKGridView.m; sourceTree = "<group>"; tabWidth = 4; };
 		1A32AD8713DCDFC200E8CC7C /* KKGridViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KKGridViewCell.h; sourceTree = "<group>"; };
 		1A32AD8813DCDFC200E8CC7C /* KKGridViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KKGridViewCell.m; sourceTree = "<group>"; };
 		1A3F1B6E13E34A61006747A3 /* KKGridViewUpdateStack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KKGridViewUpdateStack.h; sourceTree = "<group>"; };

--- a/KKGridView/KKBlocksDelegate.h
+++ b/KKGridView/KKBlocksDelegate.h
@@ -1,0 +1,29 @@
+//
+//  KKBlocksDelegate.h
+//  KKGridView
+//
+//  Created by Jonathan Sterling on 12/16/11.
+//  Copyright (c) 2011 kxk design. All rights reserved.
+//
+
+#import <KKGridView/KKGridView.h>
+
+// Use KKBlocksDelegate if you prefer blocks to implementing protocols.
+// You need to maintain ownership of this object, since the dataSource/delegate
+// references are weak.
+
+@interface KKBlocksDelegate : NSObject <KKGridViewDataSource, KKGridViewDelegate>
+@property (copy) KKGridViewCell *(^cell)(KKGridView *gridView, KKIndexPath *indexPath);
+@property (copy) NSUInteger (^numberOfSections)(KKGridView *gridView);
+@property (copy) NSUInteger (^numberOfItems)(KKGridView *gridView, NSUInteger section);
+@property (copy) CGFloat (^heightForHeader)(KKGridView *gridView, NSUInteger section);
+@property (copy) CGFloat (^heightForFooter)(KKGridView *gridView, NSUInteger section);
+@property (copy) UIView *(^viewForHeader)(KKGridView *gridView, NSUInteger section);
+@property (copy) UIView *(^viewForFooter)(KKGridView *gridView, NSUInteger section);
+
+@property (copy) void (^didSelectItem)(KKGridView *gridView, KKIndexPath *indexPath);
+@property (copy) void (^didDeselectItem)(KKGridView *gridView, KKIndexPath *indexPath);
+@property (copy) KKIndexPath *(^willSelectItem)(KKGridView *gridView, KKIndexPath *indexPath);
+@property (copy) KKIndexPath *(^willDeselectItem)(KKGridView *gridView, KKIndexPath *indexPath);
+@property (copy) void (^willDisplayCell)(KKGridView *gridView, KKGridViewCell *cell, KKIndexPath *indexPath);
+@end

--- a/KKGridView/KKBlocksDelegate.m
+++ b/KKGridView/KKBlocksDelegate.m
@@ -1,0 +1,93 @@
+//
+//  KKBlocksDelegate.m
+//  KKGridView
+//
+//  Created by Jonathan Sterling on 12/16/11.
+//  Copyright (c) 2011 kxk design. All rights reserved.
+//
+
+#import "KKBlocksDelegate.h"
+
+@implementation KKBlocksDelegate
+@synthesize cell = _cell;
+@synthesize numberOfSections = _numberOfSections;
+@synthesize numberOfItems = _numberOfItems;
+@synthesize heightForHeader = _heightForHeader;
+@synthesize heightForFooter = _heightForFooter;
+@synthesize viewForHeader = _viewForHeader;
+@synthesize viewForFooter = _viewForFooter;
+
+@synthesize didSelectItem = _didSelectItem;
+@synthesize didDeselectItem = _didDeselectItem;
+@synthesize willSelectItem = _willSelectItem;
+@synthesize willDeselectItem = _willDeselectItem;
+@synthesize willDisplayCell = _willDisplayCell;
+
+#pragma mark - KKGridViewDataSource
+
+- (NSUInteger)gridView:(KKGridView *)gridView numberOfItemsInSection:(NSUInteger)section
+{
+    return _numberOfItems ? _numberOfItems(gridView,section) : 0;
+}
+
+- (KKGridViewCell *)gridView:(KKGridView *)gridView cellForItemAtIndexPath:(KKIndexPath *)indexPath
+{
+    return _cell ? _cell(gridView,indexPath) : [KKGridViewCell cellForGridView:gridView];
+}
+
+- (NSUInteger)numberOfSectionsInGridView:(KKGridView *)gridView
+{
+    return _numberOfSections ? _numberOfSections(gridView) : 1;
+}
+
+- (CGFloat)gridView:(KKGridView *)gridView heightForHeaderInSection:(NSUInteger)section
+{
+    return _heightForHeader ? _heightForHeader(gridView,section) : 25.0;
+}
+
+- (CGFloat)gridView:(KKGridView *)gridView heightForFooterInSection:(NSUInteger)section
+{
+    return _heightForFooter ? _heightForFooter(gridView,section) : 25.0;
+}
+
+- (UIView *)gridView:(KKGridView *)gridView viewForHeaderInSection:(NSUInteger)section
+{
+    return _viewForHeader ? _viewForHeader(gridView,section) : nil;
+}
+
+- (UIView *)gridView:(KKGridView *)gridView viewForFooterInSection:(NSUInteger)section
+{
+    return _viewForFooter ? _viewForFooter(gridView,section) : nil;
+}
+
+#pragma mark - KKGridViewDelegate
+
+- (void)gridView:(KKGridView *)gridView didSelectItemAtIndexPath:(KKIndexPath *)indexPath
+{
+  if (_didSelectItem)
+    _didSelectItem(gridView,indexPath);
+}
+
+- (void)gridView:(KKGridView *)gridView didDeselectItemAtIndexPath:(KKIndexPath *)indexPath
+{
+  if (_didDeselectItem)
+    _didDeselectItem(gridView,indexPath);
+}
+
+- (KKIndexPath *)gridView:(KKGridView *)gridView willSelectItemAtIndexPath:(KKIndexPath *)indexPath
+{
+  return _willSelectItem ? _willSelectItem(gridView,indexPath) : indexPath;
+}
+
+- (KKIndexPath *)gridView:(KKGridView *)gridView willDeselectItemAtIndexPath:(KKIndexPath *)indexPath
+{
+  return _willDeselectItem ? _willDeselectItem(gridView,indexPath) : indexPath;
+}
+
+- (void)gridView:(KKGridView *)gridView willDisplayCell:(KKGridViewCell *)cell atIndexPath:(KKIndexPath *)indexPath
+{
+  if (_willDisplayCell)
+    _willDisplayCell(gridView,cell,indexPath);
+}
+
+@end

--- a/KKGridView/KKGridView.h
+++ b/KKGridView/KKGridView.h
@@ -10,13 +10,6 @@
 #import <KKGridView/KKIndexPath.h>
 #import <KKGridView/Definitions.h>
 
-typedef KKGridViewCell * (^KKGridViewCellForItemAtIndexPath)(KKGridView *gridView, KKIndexPath *indexPath);
-typedef NSUInteger (^KKGridViewNumberOfSections)(KKGridView *gridView);
-typedef NSUInteger (^KKGridViewNumberOfItemsInSection)(KKGridView *gridView, NSUInteger section);
-typedef CGFloat (^KKGridViewHeightForHeaderInSection)(KKGridView *gridView, NSUInteger section);
-typedef CGFloat (^KKGridViewHeightForFooterInSection)(KKGridView *gridView, NSUInteger section);
-typedef UIView * (^KKGridViewViewForHeaderInSection)(KKGridView *gridView, NSUInteger section);
-typedef UIView * (^KKGridViewViewForFooterInSection)(KKGridView *gridView, NSUInteger section);
 typedef void (^KKGridViewIndexPath)(KKGridView *gridView, KKIndexPath *indexPath);
 typedef KKIndexPath * (^KKGridViewReturnPath)(KKGridView *gridView, KKIndexPath *indexPath);
 typedef void (^KKGridViewWillDisplayCellAtPath)(KKGridView *gridView, KKGridViewCell *cell, KKIndexPath *indexPath);
@@ -40,6 +33,8 @@ typedef enum {
     KKGridViewAnimationNone
 } KKGridViewAnimation;
 
+@protocol KKGridViewDataSource;
+
 @interface KKGridView : UIScrollView
 
 #pragma mark - Properties
@@ -53,15 +48,8 @@ typedef enum {
 @property (nonatomic, readonly) NSUInteger numberOfColumns;
 @property (nonatomic, readonly) NSUInteger numberOfSections;
 
-#pragma mark - Data Source
-
-@property (nonatomic, copy) KKGridViewCellForItemAtIndexPath cellBlock;
-@property (nonatomic, copy) KKGridViewNumberOfSections numberOfSectionsBlock;
-@property (nonatomic, copy) KKGridViewNumberOfItemsInSection numberOfItemsInSectionBlock;
-@property (nonatomic, copy) KKGridViewHeightForHeaderInSection heightForHeaderInSectionBlock;
-@property (nonatomic, copy) KKGridViewHeightForFooterInSection heightForFooterInSectionBlock;
-@property (nonatomic, copy) KKGridViewViewForHeaderInSection viewForHeaderInSectionBlock;
-@property (nonatomic, copy) KKGridViewViewForFooterInSection viewForFooterInSectionBlock;
+#pragma mark - Data Source and Delegate
+@property (nonatomic, __kk_weak) id <KKGridViewDataSource> dataSource;
 
 #pragma mark - Delegate
 
@@ -107,3 +95,15 @@ typedef enum {
 
 @end
 
+
+@protocol KKGridViewDataSource <NSObject>
+@required
+- (NSUInteger)gridView:(KKGridView *)gridView numberOfItemsInSection:(NSUInteger)section;
+- (KKGridViewCell *)gridView:(KKGridView *)gridView cellForItemAtIndexPath:(KKIndexPath *)indexPath;
+@optional
+- (NSUInteger)numberOfSectionsInGridView:(KKGridView *)gridView;
+- (CGFloat)gridView:(KKGridView *)gridView heightForHeaderInSection:(NSUInteger)section;
+- (CGFloat)gridView:(KKGridView *)gridView heightForFooterInSection:(NSUInteger)section;
+- (UIView *)gridView:(KKGridView *)gridView viewForHeaderInSection:(NSUInteger)section;
+- (UIView *)gridView:(KKGridView *)gridView viewForFooterInSection:(NSUInteger)section;
+@end

--- a/KKGridView/KKGridView.h
+++ b/KKGridView/KKGridView.h
@@ -10,10 +10,6 @@
 #import <KKGridView/KKIndexPath.h>
 #import <KKGridView/Definitions.h>
 
-typedef void (^KKGridViewIndexPath)(KKGridView *gridView, KKIndexPath *indexPath);
-typedef KKIndexPath * (^KKGridViewReturnPath)(KKGridView *gridView, KKIndexPath *indexPath);
-typedef void (^KKGridViewWillDisplayCellAtPath)(KKGridView *gridView, KKGridViewCell *cell, KKIndexPath *indexPath);
-
 typedef enum {
     KKGridViewScrollPositionNone,        
     KKGridViewScrollPositionTop,    
@@ -34,6 +30,7 @@ typedef enum {
 } KKGridViewAnimation;
 
 @protocol KKGridViewDataSource;
+@protocol KKGridViewDelegate;
 
 @interface KKGridView : UIScrollView
 
@@ -50,14 +47,7 @@ typedef enum {
 
 #pragma mark - Data Source and Delegate
 @property (nonatomic, __kk_weak) id <KKGridViewDataSource> dataSource;
-
-#pragma mark - Delegate
-
-@property (nonatomic, copy) KKGridViewIndexPath didSelectIndexPathBlock;
-@property (nonatomic, copy) KKGridViewReturnPath willSelectItemAtIndexPathBlock;
-@property (nonatomic, copy) KKGridViewReturnPath willDeselectItemAtIndexPathBlock;
-@property (nonatomic, copy) KKGridViewIndexPath didDeselectIndexPathBlock;
-@property (nonatomic, copy) KKGridViewWillDisplayCellAtPath willDisplayCellAtPathBlock;
+@property (nonatomic, __kk_weak) id <KKGridViewDelegate> gridDelegate;
 
 #pragma mark - Getters
 
@@ -106,4 +96,13 @@ typedef enum {
 - (CGFloat)gridView:(KKGridView *)gridView heightForFooterInSection:(NSUInteger)section;
 - (UIView *)gridView:(KKGridView *)gridView viewForHeaderInSection:(NSUInteger)section;
 - (UIView *)gridView:(KKGridView *)gridView viewForFooterInSection:(NSUInteger)section;
+@end
+
+@protocol KKGridViewDelegate <NSObject>
+@optional
+- (void)gridView:(KKGridView *)gridView didSelectItemAtIndexPath:(KKIndexPath *)indexPath;
+- (void)gridView:(KKGridView *)gridView didDeselectItemAtIndexPath:(KKIndexPath *)indexPath;
+- (KKIndexPath *)gridView:(KKGridView *)gridView willSelectItemAtIndexPath:(KKIndexPath *)indexPath;
+- (KKIndexPath *)gridView:(KKGridView *)gridView willDeselectItemAtIndexPath:(KKIndexPath *)indexPath;
+- (void)gridView:(KKGridView *)gridView willDisplayCell:(KKGridViewCell *)cell atIndexPath:(KKIndexPath *)indexPath;
 @end

--- a/KKGridView/KKGridView.m
+++ b/KKGridView/KKGridView.m
@@ -44,6 +44,15 @@ struct KKSectionMetrics {
     BOOL _staggerForInsertion; // Animate items or not
     BOOL _needsAccessoryReload;
     KKGridViewUpdateStack *_updateStack; // Update manager
+    
+    // DataSource/Delegate flags
+    struct {
+        unsigned int numberOfSections:1;
+        unsigned int heightForHeader:1;
+        unsigned int heightForFooter:1;
+        unsigned int viewForHeader:1;
+        unsigned int viewForFooter:1;
+    } _dataSourceRespondsTo;
 }
 
 // Initialization
@@ -93,6 +102,7 @@ struct KKSectionMetrics {
 @implementation KKGridView
 
 // Main Properties
+@synthesize dataSource = _dataSource;
 @synthesize allowsMultipleSelection = _allowsMultipleSelection;
 @synthesize cellPadding = _cellPadding;
 @synthesize cellSize = _cellSize;
@@ -101,15 +111,6 @@ struct KKSectionMetrics {
 @synthesize numberOfColumns = _numberOfColumns;
 @synthesize numberOfSections = _numberOfSections;
 @synthesize backgroundView = _backgroundView;
-
-// Data Source Blocks
-@synthesize cellBlock = _cellBlock;
-@synthesize numberOfSectionsBlock = _numberOfSectionsBlock;
-@synthesize numberOfItemsInSectionBlock = _numberOfItemsInSectionBlock;
-@synthesize heightForHeaderInSectionBlock = _heightForHeaderInSectionBlock;
-@synthesize heightForFooterInSectionBlock = _heightForFooterInSectionBlock;
-@synthesize viewForHeaderInSectionBlock = _viewForHeaderInSectionBlock;
-@synthesize viewForFooterInSectionBlock = _viewForFooterInSectionBlock;
 
 // Delegate Blocks
 @synthesize didSelectIndexPathBlock = _didSelectIndexPathBlock;
@@ -179,6 +180,20 @@ struct KKSectionMetrics {
 }
 
 #pragma mark - Setters
+
+- (void)setDataSource:(id<KKGridViewDataSource>)dataSource
+{
+    if (dataSource != _dataSource)
+    {
+        _dataSource = dataSource;
+        _dataSourceRespondsTo.numberOfSections = [_dataSource respondsToSelector:@selector(numberOfSectionsInGridView:)];
+        _dataSourceRespondsTo.heightForHeader = [_dataSource respondsToSelector:@selector(gridView:heightForHeaderInSection:)];
+        _dataSourceRespondsTo.heightForFooter = [_dataSource respondsToSelector:@selector(gridView:heightForFooterInSection:)];
+        _dataSourceRespondsTo.viewForHeader = [_dataSource respondsToSelector:@selector(gridView:viewForHeaderInSection:)];
+        _dataSourceRespondsTo.viewForFooter = [_dataSource respondsToSelector:@selector(gridView:viewForFooterInSection:)];
+        [self reloadData];
+    }
+}
 
 - (void)setFrame:(CGRect)frame
 {
@@ -252,48 +267,6 @@ struct KKSectionMetrics {
         [self addSubview:gridFooterView];
         [self setNeedsLayout];
     }
-}
-
-- (void)setCellBlock:(KKGridViewCellForItemAtIndexPath)cellBlock
-{
-    _cellBlock = [cellBlock copy];
-    [self reloadData];
-}
-
-- (void)setNumberOfSectionsBlock:(KKGridViewNumberOfSections)numberOfSectionsBlock
-{
-    _numberOfSectionsBlock = [numberOfSectionsBlock copy];
-    [self reloadData];
-}
-
-- (void)setNumberOfItemsInSectionBlock:(KKGridViewNumberOfItemsInSection)numberOfItemsInSectionBlock
-{
-    _numberOfItemsInSectionBlock = [numberOfItemsInSectionBlock copy];
-    [self reloadData];
-}
-
-- (void)setHeightForFooterInSectionBlock:(KKGridViewHeightForFooterInSection)heightForFooterInSectionBlock
-{
-    _heightForFooterInSectionBlock = [heightForFooterInSectionBlock copy];
-    [self reloadData];
-}
-
-- (void)setHeightForHeaderInSectionBlock:(KKGridViewHeightForHeaderInSection)heightForHeaderInSectionBlock
-{
-    _heightForHeaderInSectionBlock = [heightForHeaderInSectionBlock copy];
-    [self reloadData];
-}
-
-- (void)setViewForHeaderInSectionBlock:(KKGridViewViewForHeaderInSection)viewForHeaderInSectionBlock
-{
-    _viewForHeaderInSectionBlock = [viewForHeaderInSectionBlock copy];
-    [self reloadData];
-}
-
-- (void)setViewForFooterInSectionBlock:(KKGridViewViewForFooterInSection)viewForFooterInSectionBlock
-{
-    _viewForFooterInSectionBlock = [viewForFooterInSectionBlock copy];
-    [self reloadData];
 }
 
 #pragma mark - Root Layout Methods
@@ -597,8 +570,8 @@ struct KKSectionMetrics {
         
         if (_numberOfSections > 0) {
             numberOfRows = ceilf(sectionMetrics.itemCount / (float)_numberOfColumns);
-        } else if (_numberOfItemsInSectionBlock) {
-            numberOfRows = ceilf(_numberOfItemsInSectionBlock(self, section) / (float)_numberOfColumns);
+        } else if (_dataSource) {
+            numberOfRows = ceilf([_dataSource gridView:self numberOfItemsInSection:section] / (float)_numberOfColumns);
         }
         
         height += numberOfRows * (_cellSize.height + _cellPadding.height);
@@ -658,7 +631,7 @@ struct KKSectionMetrics {
 
 - (KKGridViewCell *)_loadCellAtVisibleIndexPath:(KKIndexPath *)indexPath
 {
-    KKGridViewCell *cell = _cellBlock(self, indexPath);
+    KKGridViewCell *cell = [_dataSource gridView:self cellForItemAtIndexPath:indexPath];
     [_visibleCells setObject:cell forKey:indexPath];
     cell.frame = [self rectForCellAtIndexPath:indexPath];
     return cell;
@@ -679,7 +652,7 @@ struct KKSectionMetrics {
 
 - (KKIndexPath *)_lastIndexPathForSection:(NSUInteger)section
 {
-    return [KKIndexPath indexPathForIndex:_numberOfItemsInSectionBlock(self, section) inSection:section];
+    return [KKIndexPath indexPathForIndex:[_dataSource gridView:self numberOfItemsInSection:section] inSection:section];
 }
 
 #pragma mark - Public Getters
@@ -768,7 +741,7 @@ struct KKSectionMetrics {
     KKIndexPath *indexPath = [KKIndexPath indexPathForIndex:0 inSection:0];
     
     for (NSUInteger section = 0; section < _numberOfSections; section++) {
-        for (NSUInteger index = 0; index < _numberOfItemsInSectionBlock(self, section); index++) {
+        for (NSUInteger index = 0; index < [_dataSource gridView:self numberOfItemsInSection:section]; index++) {
             
             indexPath.section = section;
             indexPath.index = index;
@@ -953,7 +926,7 @@ struct KKSectionMetrics {
         [views removeAllObjects];
     };
     
-    if (_heightForHeaderInSectionBlock && _viewForHeaderInSectionBlock) {
+    if (_dataSourceRespondsTo.heightForHeader && _dataSourceRespondsTo.viewForHeader) {
         clearAuxiliaryViews(_headerViews);
         if (!_headerViews)
         {
@@ -961,7 +934,7 @@ struct KKSectionMetrics {
         }
         
         for (NSUInteger section = 0; section < _numberOfSections; section++) {
-            UIView *view = self.viewForHeaderInSectionBlock(self, section);
+            UIView *view = [_dataSource gridView:self viewForHeaderInSection:section];
             KKGridViewHeader *header = [[KKGridViewHeader alloc] initWithView:view];
             [_headerViews addObject:header];
             
@@ -972,7 +945,7 @@ struct KKSectionMetrics {
         }
     }
     
-    if (_heightForFooterInSectionBlock && _viewForFooterInSectionBlock) {
+    if (_dataSourceRespondsTo.heightForFooter && _dataSourceRespondsTo.viewForFooter) {
         clearAuxiliaryViews(_footerViews);
         if (!_footerViews)
         {
@@ -980,7 +953,7 @@ struct KKSectionMetrics {
         }
         
         for (NSUInteger section = 0; section < _numberOfSections; section++) {
-            UIView *view = _viewForFooterInSectionBlock(self, section);
+            UIView *view = [_dataSource gridView:self viewForFooterInSection:section];
             KKGridViewFooter *footer = [[KKGridViewFooter alloc] initWithView:view];
             [_footerViews addObject:footer];
             
@@ -1038,7 +1011,7 @@ struct KKSectionMetrics {
 
 - (void)_reloadMetrics
 {
-    _numberOfSections = _numberOfSectionsBlock ? _numberOfSectionsBlock(self) : 1;
+    _numberOfSections = _dataSourceRespondsTo.numberOfSections ? [_dataSource numberOfSectionsInGridView:self] : 1;
     
     if (_metrics)
         free(_metrics);
@@ -1046,19 +1019,16 @@ struct KKSectionMetrics {
     _metrics = (struct KKSectionMetrics *)calloc(_numberOfSections, sizeof(struct KKSectionMetrics));
     _metricsCount = 0;
     
-    for (NSUInteger section = 0; section < _numberOfSections; section++)
+    for (_metricsCount = 0; _metricsCount < _numberOfSections; _metricsCount++)
     {
-        struct KKSectionMetrics sectionMetrics;
+        struct KKSectionMetrics *sectionMetrics = &_metrics[_metricsCount];
         
-        if (_heightForHeaderInSectionBlock)
-            sectionMetrics.headerHeight = _heightForHeaderInSectionBlock(self, section);
-        if (_heightForFooterInSectionBlock)
-            sectionMetrics.footerHeight = _heightForFooterInSectionBlock(self, section);
-        if (_numberOfItemsInSectionBlock)
-            sectionMetrics.itemCount = _numberOfItemsInSectionBlock(self, section);
+        sectionMetrics->itemCount = [_dataSource gridView:self numberOfItemsInSection:_metricsCount];
         
-        _metrics[section] = sectionMetrics;
-        _metricsCount++;        
+        if (_dataSourceRespondsTo.heightForHeader)
+            sectionMetrics->headerHeight = [_dataSource gridView:self heightForHeaderInSection:_metricsCount];
+        if (_dataSourceRespondsTo.heightForFooter)
+            sectionMetrics->footerHeight = [_dataSource gridView:self heightForFooterInSection:_metricsCount];
     }
 }
 

--- a/KKGridView/KKGridView.m
+++ b/KKGridView/KKGridView.m
@@ -934,9 +934,12 @@ struct KKSectionMetrics {
 {
     [self reloadContentSize];
     
-    void (^clearAuxiliaryViews)(NSMutableArray *) = ^(NSMutableArray *views)
-    {
-        [[views valueForKey:@"view"] makeObjectsPerformSelector:@selector(removeFromSuperview)];
+    void (^clearAuxiliaryViews)(NSMutableArray *) = ^(NSMutableArray *views) {
+        for (id view in [views valueForKey:@"view"]) {
+            if (view != [NSNull null])
+                [view removeFromSuperview];
+        }
+        
         [views removeAllObjects];
     };
     

--- a/KKGridView/KKGridView.m
+++ b/KKGridView/KKGridView.m
@@ -1134,7 +1134,7 @@ struct KKSectionMetrics {
         [UIView commitAnimations];
 }
 
-- (KKIndexPath*) indexPathForSelectedCell {
+- (KKIndexPath*)indexPathForSelectedCell {
     if (!_allowsMultipleSelection) {
         return [_selectedIndexPaths anyObject];
     } else {

--- a/KKGridView/KKGridViewController.h
+++ b/KKGridView/KKGridViewController.h
@@ -8,7 +8,7 @@
 
 #import <KKGridView/KKGridView.h>
 
-@interface KKGridViewController : UIViewController
+@interface KKGridViewController : UIViewController <KKGridViewDataSource, KKGridViewDelegate>
 
 @property (nonatomic, strong) KKGridView *gridView;
 

--- a/KKGridView/KKGridViewController.m
+++ b/KKGridView/KKGridViewController.m
@@ -18,7 +18,21 @@
     [super loadView];
     _gridView = [[KKGridView alloc] initWithFrame:self.view.bounds];
     _gridView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
+    _gridView.dataSource = self;
+    _gridView.gridDelegate = self;
     self.view = _gridView;
+}
+
+#pragma mark - KKGridViewDataSource
+
+- (NSUInteger)gridView:(KKGridView *)gridView numberOfItemsInSection:(NSUInteger)section
+{
+    return 0;
+}
+
+- (KKGridViewCell *)gridView:(KKGridView *)gridView cellForItemAtIndexPath:(KKIndexPath *)indexPath
+{
+    return [KKGridViewCell cellForGridView:gridView];
 }
 
 @end


### PR DESCRIPTION
So, it was a good experiment to try blocks for delegation. I just don't think it's really practical for something like this, though. It makes consumers write _more_ code than _less_ (see #54). That's why I brought back `<KKGridViewDataSource>` and `<KKGridViewDelegate>`.

For those who want to use blocks, I have also included a class `KKBlocksDelegate`. I'm sure someone can think of a better name than this (please do!); the basic idea is that your controller owns one of these objects, sets its block properties, and sets it as the `dataSource` and `gridDelegate` of the grid view. If someone really wants it, we could make this into a clever metaprogramming-heavy proxy thing, but I don't feel that that is necessary at this point. Something that clever would likely introduce more bugs than help us with anything.
