### PR TITLE
Implementation for #16, Automatic Headers/Footers

### DIFF
--- a/Examples/GridViewDemo/GridViewDemo/GridViewDemoViewController.h
+++ b/Examples/GridViewDemo/GridViewDemo/GridViewDemoViewController.h
@@ -11,7 +11,5 @@
 @interface GridViewDemoViewController : KKGridViewController <UISearchBarDelegate>
 
 @property (nonatomic) NSUInteger firstSectionCount;
-@property (nonatomic, strong) NSMutableArray *footerViews;
-@property (nonatomic, strong) NSMutableArray *headerViews;
 
 @end

--- a/Examples/GridViewDemo/GridViewDemo/GridViewDemoViewController.m
+++ b/Examples/GridViewDemo/GridViewDemo/GridViewDemoViewController.m
@@ -16,30 +16,12 @@ static const NSUInteger kNumSection = 40;
 
 @implementation GridViewDemoViewController
 @synthesize firstSectionCount = _firstSectionCount;
-@synthesize footerViews = _footerViews;
-@synthesize headerViews = _headerViews;
 
 #pragma mark - View lifecycle
 
 - (void)loadView
 {
     [super loadView];
-    _headerViews = [[NSMutableArray alloc] initWithCapacity:kNumSection];
-    _footerViews = [[NSMutableArray alloc] initWithCapacity:kNumSection];
-    
-    for (NSUInteger section = 0; section < kNumSection; section++) {
-        UILabel *header = [[UILabel alloc] initWithFrame:CGRectZero];
-        header.backgroundColor = [UIColor grayColor];
-        header.textAlignment = UITextAlignmentCenter;
-        header.text = [NSString stringWithFormat:@"Header %d", section + 1];
-        [_headerViews addObject:header];
-        
-        UILabel *footer = [[UILabel alloc] initWithFrame:CGRectZero];
-        footer.textAlignment = UITextAlignmentCenter;
-        footer.text = [NSString stringWithFormat:@"Footer %d", section + 1];
-        footer.backgroundColor = [UIColor colorWithRed:0.772f green:0.788f blue:0.816f alpha:1.f];
-        [_footerViews addObject:footer];
-    }
     
     _firstSectionCount = 7;
     
@@ -118,14 +100,14 @@ static const NSUInteger kNumSection = 40;
     return 25.f;
 }
 
-- (UIView *)gridView:(KKGridView *)gridView viewForHeaderInSection:(NSUInteger)section
+- (NSString *)gridView:(KKGridView *)gridView titleForHeaderInSection:(NSUInteger)section
 {
-    return [self.headerViews objectAtIndex:section];
+    return [NSString stringWithFormat:@"Header %i",section];
 }
 
-- (UIView *)gridView:(KKGridView *)gridView viewForFooterInSection:(NSUInteger)section
+- (NSString *)gridView:(KKGridView *)gridView titleForFooterInSection:(NSUInteger)section
 {
-    return [self.footerViews objectAtIndex:section];
+    return [NSString stringWithFormat:@"Footer %i",section];
 }
 
 

--- a/KKGridView/KKBlocksDelegate.h
+++ b/KKGridView/KKBlocksDelegate.h
@@ -18,6 +18,8 @@
 @property (copy) NSUInteger (^numberOfItems)(KKGridView *gridView, NSUInteger section);
 @property (copy) CGFloat (^heightForHeader)(KKGridView *gridView, NSUInteger section);
 @property (copy) CGFloat (^heightForFooter)(KKGridView *gridView, NSUInteger section);
+@property (copy) NSString *(^titleForHeader)(KKGridView *gridView, NSUInteger section);
+@property (copy) NSString *(^titleForFooter)(KKGridView *gridView, NSUInteger section);
 @property (copy) UIView *(^viewForHeader)(KKGridView *gridView, NSUInteger section);
 @property (copy) UIView *(^viewForFooter)(KKGridView *gridView, NSUInteger section);
 

--- a/KKGridView/KKBlocksDelegate.m
+++ b/KKGridView/KKBlocksDelegate.m
@@ -14,6 +14,8 @@
 @synthesize numberOfItems = _numberOfItems;
 @synthesize heightForHeader = _heightForHeader;
 @synthesize heightForFooter = _heightForFooter;
+@synthesize titleForHeader = _titleForHeader;
+@synthesize titleForFooter = _titleForFooter;
 @synthesize viewForHeader = _viewForHeader;
 @synthesize viewForFooter = _viewForFooter;
 
@@ -38,6 +40,16 @@
 - (NSUInteger)numberOfSectionsInGridView:(KKGridView *)gridView
 {
     return _numberOfSections ? _numberOfSections(gridView) : 1;
+}
+
+- (NSString *)gridView:(KKGridView *)gridView titleForHeaderInSection:(NSUInteger)section
+{
+    return _titleForHeader ? _titleForFooter(gridView,section) : @"";
+}
+
+- (NSString *)gridView:(KKGridView *)gridView titleForFooterInSection:(NSUInteger)section
+{
+    return _titleForFooter ? _titleForFooter(gridView,section) : @"";
 }
 
 - (CGFloat)gridView:(KKGridView *)gridView heightForHeaderInSection:(NSUInteger)section

--- a/KKGridView/KKGridView.h
+++ b/KKGridView/KKGridView.h
@@ -92,6 +92,8 @@ typedef enum {
 - (KKGridViewCell *)gridView:(KKGridView *)gridView cellForItemAtIndexPath:(KKIndexPath *)indexPath;
 @optional
 - (NSUInteger)numberOfSectionsInGridView:(KKGridView *)gridView;
+- (NSString *)gridView:(KKGridView *)gridView titleForHeaderInSection:(NSUInteger)section;
+- (NSString *)gridView:(KKGridView *)gridView titleForFooterInSection:(NSUInteger)section;
 - (CGFloat)gridView:(KKGridView *)gridView heightForHeaderInSection:(NSUInteger)section;
 - (CGFloat)gridView:(KKGridView *)gridView heightForFooterInSection:(NSUInteger)section;
 - (UIView *)gridView:(KKGridView *)gridView viewForHeaderInSection:(NSUInteger)section;

--- a/KKGridView/KKGridView.m
+++ b/KKGridView/KKGridView.m
@@ -1074,7 +1074,9 @@ struct KKSectionMetrics {
     
     if (_dataSourceRespondsTo.viewForHeader) {
         headerView = [_dataSource gridView:self viewForHeaderInSection:section];
-    } else if (_dataSourceRespondsTo.titleForHeader) {
+    }
+    
+    if (!headerView && _dataSourceRespondsTo.titleForHeader) {
         UILabel *label = [[UILabel alloc] initWithFrame:CGRectZero];
         label.backgroundColor = [UIColor darkGrayColor];
         label.textColor = [UIColor lightTextColor];
@@ -1094,7 +1096,9 @@ struct KKSectionMetrics {
     
     if (_dataSourceRespondsTo.viewForFooter) {
         footerView = [_dataSource gridView:self viewForFooterInSection:section];
-    } else if (_dataSourceRespondsTo.titleForHeader) {
+    }
+    
+    if (!footerView && _dataSourceRespondsTo.titleForFooter) {
         UILabel *label = [[UILabel alloc] initWithFrame:CGRectZero];
         label.backgroundColor = [UIColor colorWithRed:0.772f green:0.788f blue:0.816f alpha:1.f];
         label.textAlignment = UITextAlignmentCenter;


### PR DESCRIPTION
I've added `-gridView:titleForHeaderInSection:` and `-gridView:titleForFooterInSection:` to `<KKGridViewDataSource>`. These should behave as expected.

Consumers may continue to provide their own views in the usual way if they desire to do so.
