### PR TITLE
Cancelable Highlighting

### DIFF
--- a/KKGridView/KKGridView.h
+++ b/KKGridView/KKGridView.h
@@ -77,10 +77,10 @@ typedef enum {
 
 #pragma mark - Selection
 
-- (void)selectRowsAtIndexPaths:(NSArray *)indexPaths animated:(BOOL)animated;
-- (void)deselectRowsAtIndexPaths:(NSArray *)indexPaths animated:(BOOL)animated;
+- (void)selectItemsAtIndexPaths:(NSArray *)indexPaths animated:(BOOL)animated;
+- (void)deselectItemsAtIndexPaths:(NSArray *)indexPaths animated:(BOOL)animated;
 
-- (KKIndexPath*)indexPathForSelectedCell;
+- (KKIndexPath *)indexPathForSelectedCell;
 - (NSArray *)indexPathsForSelectedCells;
 
 @end

--- a/KKGridView/KKGridView.m
+++ b/KKGridView/KKGridView.m
@@ -718,7 +718,7 @@ struct KKSectionMetrics {
     return indexes;
 }
 
-- (KKIndexPath *)indexPathsForItemAtPoint:(CGPoint)point
+- (KKIndexPath *)indexPathForItemAtPoint:(CGPoint)point
 {
     NSArray *indexes = [self indexPathsForItemsInRect:(CGRect){ point, {1.f, 1.f } }];
     return ([indexes count] > 0) ? [indexes objectAtIndex:0] : [KKIndexPath indexPathForIndex:NSNotFound inSection:NSNotFound];
@@ -1166,7 +1166,7 @@ struct KKSectionMetrics {
 
 #pragma mark - Public Selection Methods
 
-- (void)selectRowsAtIndexPaths:(NSArray *)indexPaths animated:(BOOL)animated
+- (void)selectItemsAtIndexPaths:(NSArray *)indexPaths animated:(BOOL)animated
 {
     if (!indexPaths)
         return;
@@ -1182,7 +1182,7 @@ struct KKSectionMetrics {
         [UIView commitAnimations];
 }
 
-- (void)deselectRowsAtIndexPaths:(NSArray *)indexPaths animated:(BOOL)animated
+- (void)deselectItemsAtIndexPaths:(NSArray *)indexPaths animated:(BOOL)animated
 {
     if (!indexPaths)
         return;
@@ -1260,7 +1260,7 @@ struct KKSectionMetrics {
 
 - (void)_handleSelection:(UITapGestureRecognizer *)recognizer
 {    
-    KKIndexPath *indexPath = [self indexPathsForItemAtPoint:[recognizer locationInView:self]];
+    KKIndexPath *indexPath = [self indexPathForItemAtPoint:[recognizer locationInView:self]];
     if (_delegateRespondsTo.willSelectItem)
         indexPath = [_gridDelegate gridView:self willSelectItemAtIndexPath:indexPath];
     

--- a/KKGridView/KKGridViewCell.h
+++ b/KKGridView/KKGridViewCell.h
@@ -56,6 +56,7 @@ typedef enum {
 @property (nonatomic, copy) KKIndexPath *indexPath;
 @property (nonatomic, copy) NSString *reuseIdentifier; // For usage by KKGridView
 @property (nonatomic, getter = isSelected) BOOL selected;
+@property (nonatomic, getter = isHighlighted) BOOL highlighted;
 @property (nonatomic, strong) UIView *selectedBackgroundView; // Replaces *backgroundView when selected is YES
 @property (nonatomic) BOOL editing; // Editing state
 @property (nonatomic) KKGridViewCellAccessoryType accessoryType; // Default is none.


### PR DESCRIPTION
The expected behavior is that when you touch down on a cell, it is highlighted, and that touch can be cancelled in the normal way; if you release your touch without moving your finger off of the cell, then you've selected it. This is how things work in `UITableView`, and this is how it works in `KKGridView` now too.

It's all done with a single gesture recognizer; this seems to work, but it's a little complex. There's a little bit of wacky stuff that had to be done to make this interact in the right way with the panning gesture recognizer of the scrollview. I'm definitely open to superior ways of dealing with this.

I didn't push this directly to master because I wanted to make sure that people were comfortable with the behavior as I've written it. 
