### PR TITLE
Add basic nib support

### DIFF
--- a/KKGridView/KKGridView.h
+++ b/KKGridView/KKGridView.h
@@ -46,8 +46,8 @@ typedef enum {
 @property (nonatomic, readonly) NSUInteger numberOfSections;
 
 #pragma mark - Data Source and Delegate
-@property (nonatomic, __kk_weak) id <KKGridViewDataSource> dataSource;
-@property (nonatomic, __kk_weak) id <KKGridViewDelegate> gridDelegate;
+@property (nonatomic, __kk_weak) IBOutlet id <KKGridViewDataSource> dataSource;
+@property (nonatomic, __kk_weak) IBOutlet id <KKGridViewDelegate> gridDelegate;
 
 #pragma mark - Getters
 

--- a/KKGridView/KKGridViewCell.h
+++ b/KKGridView/KKGridViewCell.h
@@ -51,13 +51,13 @@ typedef enum {
 
 #pragma mark - Properties
 
-@property (nonatomic, strong) UIView *backgroundView; // Underneath contentView, use this to customize backgrounds
-@property (nonatomic, strong) UIView *contentView; // Where all subviews should be.
+@property (nonatomic, strong) IBOutlet UIView *backgroundView; // Underneath contentView, use this to customize backgrounds
+@property (nonatomic, strong) IBOutlet UIView *contentView; // Where all subviews should be.
 @property (nonatomic, copy) KKIndexPath *indexPath;
 @property (nonatomic, copy) NSString *reuseIdentifier; // For usage by KKGridView
 @property (nonatomic, getter = isSelected) BOOL selected;
 @property (nonatomic, getter = isHighlighted) BOOL highlighted;
-@property (nonatomic, strong) UIView *selectedBackgroundView; // Replaces *backgroundView when selected is YES
+@property (nonatomic, strong) IBOutlet UIView *selectedBackgroundView; // Replaces *backgroundView when selected is YES
 @property (nonatomic) BOOL editing; // Editing state
 @property (nonatomic) KKGridViewCellAccessoryType accessoryType; // Default is none.
 @property (nonatomic) KKGridViewCellAccessoryPosition accessoryPosition; // Default is quadrant 1.

--- a/KKGridView/KKGridViewCell.m
+++ b/KKGridView/KKGridViewCell.m
@@ -81,6 +81,32 @@
     return self;
 }
 
+- (void)awakeFromNib {
+	
+	if (!_contentView) {
+		_contentView = [[UIView alloc] initWithFrame:self.bounds];
+		_contentView.backgroundColor = [UIColor whiteColor];
+	}
+	[self addSubview:_contentView];
+	
+	if (!_backgroundView) {
+		_backgroundView = [[UIView alloc] initWithFrame:self.bounds];
+		_backgroundView.backgroundColor = [UIColor whiteColor];
+	}
+	[self addSubview:_backgroundView];
+	
+	if (!_selectedBackgroundView) {
+		_selectedBackgroundView = [[UIView alloc] initWithFrame:self.bounds];
+		_selectedBackgroundView.backgroundColor = [UIColor colorWithPatternImage:[self _defaultBlueBackgroundRendition]];
+	}
+	_selectedBackgroundView.hidden = YES;
+	_selectedBackgroundView.alpha = 0.f;
+	[self addSubview:_selectedBackgroundView];
+	[self bringSubviewToFront:_contentView];
+	
+	[_contentView addObserver:self forKeyPath:@"backgroundColor" options:NSKeyValueObservingOptionNew context:NULL];
+}
+
 - (void)dealloc
 {
     [_contentView removeObserver:self forKeyPath:@"backgroundColor"];


### PR DESCRIPTION
These changes allow cells to be laid out in Interface Builder. The IBOutlets allow you to hook up the views, which will then not get created in `-awakeFromNib` but still added to the view and observed like in `-initWithFrame:reuseIdentifier:`.
