### PR TITLE
Limit gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer: slightly

### DIFF
--- a/KKGridView/KKGridView.m
+++ b/KKGridView/KKGridView.m
@@ -1414,7 +1414,7 @@ struct KKSectionMetrics {
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-    return YES;
+    return (gestureRecognizer == _selectionRecognizer || otherGestureRecognizer == _selectionRecognizer);
 }
 
 


### PR DESCRIPTION
Trying this pull request again.

The current implementation of `gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer` is somewhat destructive. If you apply other gesture recognizers that interacts with the gridView (and the internal `UIScrollView`), the results can be a bit strange. Maybe `KKGridView` should only return the non-standard `YES` when it's the long press recognizer that's trying to be recognized simultaneously?

...either that or I can just subclass for my implementation. Let me know what you think :)
