### PR TITLE
Fixed a problem incrementing for loop in _cleanupCells

### DIFF
--- a/KKGridView/KKGridView.m
+++ b/KKGridView/KKGridView.m
@@ -588,7 +588,7 @@ struct KKSectionMetrics {
         }
     }
     
-    for (NSUInteger i = 0; i < cellCount; ++i) {
+    for (NSUInteger i = 0; i < cellCount; i++) {
         cell_info_t pair = cellsToRemove[i];
         KKGridViewCell *cell = pair.cell;
         


### PR DESCRIPTION
Some cells would be duplicated and stay on screen, on top of one another. Not typically a problem unless you're using transparent backgrounds, as seen in this screenshot: http://ashfurrow.com/iplusplus.png
