### PR TITLE
Only run the static analyzer in Release builds.

### DIFF
--- a/KKGridView.xcodeproj/project.pbxproj
+++ b/KKGridView.xcodeproj/project.pbxproj
@@ -321,7 +321,7 @@
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = "include/$(PROJECT_NAME)";
-				RUN_CLANG_STATIC_ANALYZER = YES;
+				RUN_CLANG_STATIC_ANALYZER = NO;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -343,6 +343,7 @@
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = "include/$(PROJECT_NAME)";
+				RUN_CLANG_STATIC_ANALYZER = YES;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;


### PR DESCRIPTION
As discussed in a [previous pull request](https://github.com/kolinkrewinkel/KKGridView/pull/109), it’s a pity to tax project build times by running the static analyzer with each build. This patch only lets the analyzer run during a Release build.
