### PR TITLE
Set delegate to nil when deallocating

### DIFF
--- a/KKGridView/KKGridView.h
+++ b/KKGridView/KKGridView.h
@@ -29,8 +29,33 @@ typedef enum {
     KKGridViewAnimationNone
 } KKGridViewAnimation;
 
-@protocol KKGridViewDataSource;
-@protocol KKGridViewDelegate;
+@class KKGridView;
+
+@protocol KKGridViewDataSource <NSObject>
+@required
+- (NSUInteger)gridView:(KKGridView *)gridView numberOfItemsInSection:(NSUInteger)section;
+- (KKGridViewCell *)gridView:(KKGridView *)gridView cellForItemAtIndexPath:(KKIndexPath *)indexPath;
+@optional
+- (NSUInteger)numberOfSectionsInGridView:(KKGridView *)gridView;
+- (NSString *)gridView:(KKGridView *)gridView titleForHeaderInSection:(NSUInteger)section;
+- (NSString *)gridView:(KKGridView *)gridView titleForFooterInSection:(NSUInteger)section;
+- (CGFloat)gridView:(KKGridView *)gridView heightForHeaderInSection:(NSUInteger)section;
+- (CGFloat)gridView:(KKGridView *)gridView heightForFooterInSection:(NSUInteger)section;
+- (UIView *)gridView:(KKGridView *)gridView viewForHeaderInSection:(NSUInteger)section;
+- (UIView *)gridView:(KKGridView *)gridView viewForFooterInSection:(NSUInteger)section;
+- (UIView *)gridView:(KKGridView *)gridView viewForRow:(NSUInteger)row inSection:(NSUInteger)section; // a row is compromised of however many cells fit in a column of a given section
+- (NSArray *)sectionIndexTitlesForGridView:(KKGridView *)gridView;
+- (NSInteger)gridView:(KKGridView *)gridView sectionForSectionIndexTitle:(NSString *)title atIndex:(NSInteger)index;
+@end
+
+@protocol KKGridViewDelegate <NSObject, UIScrollViewDelegate>
+@optional
+- (void)gridView:(KKGridView *)gridView didSelectItemAtIndexPath:(KKIndexPath *)indexPath;
+- (void)gridView:(KKGridView *)gridView didDeselectItemAtIndexPath:(KKIndexPath *)indexPath;
+- (KKIndexPath *)gridView:(KKGridView *)gridView willSelectItemAtIndexPath:(KKIndexPath *)indexPath;
+- (KKIndexPath *)gridView:(KKGridView *)gridView willDeselectItemAtIndexPath:(KKIndexPath *)indexPath;
+- (void)gridView:(KKGridView *)gridView willDisplayCell:(KKGridViewCell *)cell atIndexPath:(KKIndexPath *)indexPath;
+@end
 
 @interface KKGridView : UIScrollView
 
@@ -47,7 +72,7 @@ typedef enum {
 
 #pragma mark - Data Source and Delegate
 @property (nonatomic, kk_weak) IBOutlet id <KKGridViewDataSource> dataSource;
-@property (nonatomic, kk_weak) IBOutlet id <KKGridViewDelegate> gridDelegate;
+@property (nonatomic, kk_weak) IBOutlet id <KKGridViewDelegate> delegate;
 
 #pragma mark - Getters
 
@@ -89,31 +114,4 @@ typedef enum {
 - (KKIndexPath *)indexPathForSelectedCell;
 - (NSArray *)indexPathsForSelectedCells;
 
-@end
-
-
-@protocol KKGridViewDataSource <NSObject>
-@required
-- (NSUInteger)gridView:(KKGridView *)gridView numberOfItemsInSection:(NSUInteger)section;
-- (KKGridViewCell *)gridView:(KKGridView *)gridView cellForItemAtIndexPath:(KKIndexPath *)indexPath;
-@optional
-- (NSUInteger)numberOfSectionsInGridView:(KKGridView *)gridView;
-- (NSString *)gridView:(KKGridView *)gridView titleForHeaderInSection:(NSUInteger)section;
-- (NSString *)gridView:(KKGridView *)gridView titleForFooterInSection:(NSUInteger)section;
-- (CGFloat)gridView:(KKGridView *)gridView heightForHeaderInSection:(NSUInteger)section;
-- (CGFloat)gridView:(KKGridView *)gridView heightForFooterInSection:(NSUInteger)section;
-- (UIView *)gridView:(KKGridView *)gridView viewForHeaderInSection:(NSUInteger)section;
-- (UIView *)gridView:(KKGridView *)gridView viewForFooterInSection:(NSUInteger)section;
-- (UIView *)gridView:(KKGridView *)gridView viewForRow:(NSUInteger)row inSection:(NSUInteger)section; // a row is compromised of however many cells fit in a column of a given section
-- (NSArray *)sectionIndexTitlesForGridView:(KKGridView *)gridView;
-- (NSInteger)gridView:(KKGridView *)gridView sectionForSectionIndexTitle:(NSString *)title atIndex:(NSInteger)index;
-@end
-
-@protocol KKGridViewDelegate <NSObject>
-@optional
-- (void)gridView:(KKGridView *)gridView didSelectItemAtIndexPath:(KKIndexPath *)indexPath;
-- (void)gridView:(KKGridView *)gridView didDeselectItemAtIndexPath:(KKIndexPath *)indexPath;
-- (KKIndexPath *)gridView:(KKGridView *)gridView willSelectItemAtIndexPath:(KKIndexPath *)indexPath;
-- (KKIndexPath *)gridView:(KKGridView *)gridView willDeselectItemAtIndexPath:(KKIndexPath *)indexPath;
-- (void)gridView:(KKGridView *)gridView willDisplayCell:(KKGridViewCell *)cell atIndexPath:(KKIndexPath *)indexPath;
 @end

--- a/KKGridView/KKGridView.h
+++ b/KKGridView/KKGridView.h
@@ -72,7 +72,7 @@ typedef enum {
 
 #pragma mark - Data Source and Delegate
 @property (nonatomic, kk_weak) IBOutlet id <KKGridViewDataSource> dataSource;
-@property (nonatomic, kk_weak) IBOutlet id <KKGridViewDelegate> delegate;
+@property (nonatomic, assign)  IBOutlet id <KKGridViewDelegate> delegate;
 
 #pragma mark - Getters
 

--- a/KKGridView/KKGridView.m
+++ b/KKGridView/KKGridView.m
@@ -206,6 +206,7 @@ struct KKSectionMetrics {
 
 - (void)dealloc
 {
+    [self setDelegate:nil];
     [self removeObserver:self forKeyPath:@"contentOffset"];
     [self removeObserver:self forKeyPath:@"tracking"];
     [self removeGestureRecognizer:_selectionRecognizer];

--- a/KKGridView/KKGridView.m
+++ b/KKGridView/KKGridView.m
@@ -206,7 +206,7 @@ struct KKSectionMetrics {
 
 - (void)dealloc
 {
-    [self setDelegate:nil];
+    [super setDelegate:nil];
     [self removeObserver:self forKeyPath:@"contentOffset"];
     [self removeObserver:self forKeyPath:@"tracking"];
     [self removeGestureRecognizer:_selectionRecognizer];

--- a/KKGridView/KKGridView.m
+++ b/KKGridView/KKGridView.m
@@ -1347,22 +1347,20 @@ struct KKSectionMetrics {
     }];
 }
 
-- (void)deselectAll: (BOOL)animated
+- (void)deselectAll:(BOOL)animated
 {
     [KKGridView animateIf:animated delay:0.f options:0 block:^{
         [self _deselectAll];
     }];
 }
 
-- (KKIndexPath*)indexPathForSelectedCell {
-    if (!_allowsMultipleSelection) {
-        return [_selectedIndexPaths anyObject];
-    } else {
-        return nil;
-    }
+- (KKIndexPath*)indexPathForSelectedCell
+{
+    return !_allowsMultipleSelection ? _selectedIndexPaths.anyObject : nil;
 }
 
-- (NSArray *)indexPathsForSelectedCells {
+- (NSArray *)indexPathsForSelectedCells
+{
     return [_selectedIndexPaths allObjects];
 }
 
@@ -1438,7 +1436,7 @@ struct KKSectionMetrics {
     if (_selectedIndexPaths.count > 0 && _delegateRespondsTo.willDeselectItem && indexPath.index != NSNotFound && indexPath.section != NSNotFound) {
         KKIndexPath *redirectedPath = [_gridDelegate gridView:self willDeselectItemAtIndexPath:indexPath];
         if (redirectedPath != nil && ![redirectedPath isEqual:indexPath]) {
-            indexPath = redirectedPath ? redirectedPath : indexPath;
+            indexPath = redirectedPath;
         }
     }
     

--- a/KKGridView/KKGridView.m
+++ b/KKGridView/KKGridView.m
@@ -22,7 +22,7 @@ struct KKSectionMetrics {
     NSUInteger itemCount;
 };
 
-@interface KKGridView () <UIGestureRecognizerDelegate,UIScrollViewDelegate> {
+@interface KKGridView () <UIGestureRecognizerDelegate> {
     // View-wrapper containers
     NSMutableArray *_footerViews;
     NSMutableArray *_rowViews;
@@ -135,7 +135,7 @@ struct KKSectionMetrics {
 @implementation KKGridView
 
 @synthesize dataSource = _dataSource;
-@synthesize gridDelegate = _gridDelegate;
+@dynamic delegate;
 @synthesize allowsMultipleSelection = _allowsMultipleSelection;
 @synthesize cellPadding = _cellPadding;
 @synthesize cellSize = _cellSize;
@@ -242,12 +242,12 @@ struct KKSectionMetrics {
     }
 }
 
-- (void)setGridDelegate:(id<KKGridViewDelegate>)gridDelegate
+- (void)setDelegate:(id<KKGridViewDelegate>)delegate
 {
-    if (gridDelegate != _gridDelegate)
+    if (delegate != self.delegate)
     {
-        _gridDelegate = gridDelegate;
-#define RESPONDS_TO(sel) [_gridDelegate respondsToSelector:@selector(sel)]
+        [super setDelegate:delegate];
+#define RESPONDS_TO(sel) [self.delegate respondsToSelector:@selector(sel)]
         _delegateRespondsTo.didSelectItem    = RESPONDS_TO(gridView:didSelectItemAtIndexPath:);
         _delegateRespondsTo.willSelectItem   = RESPONDS_TO(gridView:willSelectItemAtIndexPath:);
         _delegateRespondsTo.didDeselectItem  = RESPONDS_TO(gridView:didDeselectItemAtIndexPath:);
@@ -678,7 +678,7 @@ struct KKSectionMetrics {
 - (void)_displayCell:(KKGridViewCell *)cell atIndexPath:(KKIndexPath *)indexPath withAnimation:(KKGridViewAnimation)animation
 {
     if (_delegateRespondsTo.willDisplayCell) {
-        [_gridDelegate gridView:self willDisplayCell:cell atIndexPath:indexPath];
+        [self.delegate gridView:self willDisplayCell:cell atIndexPath:indexPath];
     }
     
     if ([_updateStack hasUpdateForIndexPath:indexPath]) {
@@ -1410,7 +1410,7 @@ struct KKSectionMetrics {
     }
     
     if (_delegateRespondsTo.didSelectItem) {
-        [_gridDelegate gridView:self didSelectItemAtIndexPath:indexPath];
+        [self.delegate gridView:self didSelectItemAtIndexPath:indexPath];
     }
 }
 
@@ -1424,7 +1424,7 @@ struct KKSectionMetrics {
         
         if(_delegateRespondsTo.willDeselectItem)
         {
-            [_gridDelegate gridView:self willDeselectItemAtIndexPath:indexPath];
+            [self.delegate gridView:self willDeselectItemAtIndexPath:indexPath];
         }
     }
     
@@ -1434,7 +1434,7 @@ struct KKSectionMetrics {
 - (void)_deselectItemAtIndexPath:(KKIndexPath *)indexPath
 {
     if (_selectedIndexPaths.count > 0 && _delegateRespondsTo.willDeselectItem && indexPath.index != NSNotFound && indexPath.section != NSNotFound) {
-        KKIndexPath *redirectedPath = [_gridDelegate gridView:self willDeselectItemAtIndexPath:indexPath];
+        KKIndexPath *redirectedPath = [self.delegate gridView:self willDeselectItemAtIndexPath:indexPath];
         if (redirectedPath != nil && ![redirectedPath isEqual:indexPath]) {
             indexPath = redirectedPath;
         }
@@ -1447,7 +1447,7 @@ struct KKSectionMetrics {
     }
     
     if (_delegateRespondsTo.didDeselectItem) {
-        [_gridDelegate gridView:self didDeselectItemAtIndexPath:indexPath];
+        [self.delegate gridView:self didDeselectItemAtIndexPath:indexPath];
     }
 }
 
@@ -1487,7 +1487,7 @@ struct KKSectionMetrics {
     KKIndexPath *indexPath = [self indexPathForItemAtPoint:locationInSelf];
     
     if (state == UIGestureRecognizerStateEnded && _delegateRespondsTo.willSelectItem)
-        indexPath = [_gridDelegate gridView:self willSelectItemAtIndexPath:indexPath];
+        indexPath = [self.delegate gridView:self willSelectItemAtIndexPath:indexPath];
     
     if (!indexPath || indexPath.index == NSNotFound || indexPath.section == NSNotFound) {
         [self _cancelHighlighting];

--- a/KKGridView/KKGridViewController.m
+++ b/KKGridView/KKGridViewController.m
@@ -19,7 +19,7 @@
     _gridView = [[KKGridView alloc] initWithFrame:self.view.bounds];
     _gridView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     _gridView.dataSource = self;
-    _gridView.gridDelegate = self;
+    _gridView.delegate = self;
     self.view = _gridView;
 }
 


### PR DESCRIPTION
Otherwise the code crashes when the `KKGridView` instance gets deallocated. It appears that `[UIScrollView dealloc]` releases the delegate (which gets deallocated) and then there’s a call to `[KKGridView setDelegate:]` with a `nil` argument. The call goes through the setter, which references the already freed `_delegate` and `EXC_BAD_ACCESS` ensues.
