### PR TITLE
isDragging should work recursively

### DIFF
--- a/KKGridView/KKGridView.m
+++ b/KKGridView/KKGridView.m
@@ -227,6 +227,25 @@ struct KKSectionMetrics {
     return _selectedIndexPaths.count;
 }
 
+- (BOOL)isDragging
+{
+    BOOL recursiveDragging = [super isDragging];
+    if (recursiveDragging == NO) {
+        UIView *superview = self.superview;
+        while (superview) {
+            if ([superview isKindOfClass:[UIScrollView class]]) {
+                UIScrollView *scrollView = (UIScrollView *)superview;
+                if (scrollView.isDragging) {
+                    recursiveDragging = YES;
+                    break;
+                }
+            }
+            superview = superview.superview;
+        }
+    }
+    return recursiveDragging;
+}
+
 #pragma mark - Setters
 
 - (void)setAllowsMultipleSelection:(BOOL)allowsMultipleSelection


### PR DESCRIPTION
isDragging now returns YES if the KKGridView itself is dragging or any superview is dragging.
This is useful when you are using KKGridView inside of another ScrollView. I'm using it inside of a table view so the previous behaviour did not work.
