### PR TITLE
fix bug when I set header or footer of gridview 

### DIFF
--- a/KKGridView/KKGridView.m
+++ b/KKGridView/KKGridView.m
@@ -361,7 +361,7 @@ struct KKSectionMetrics {
     _gridFooterView = gridFooterView;
     
     [self addSubview:gridFooterView];
-    [self setNeedsLayout];
+    [self _respondToBoundsChange];
 }
 
 - (void)setGridHeaderView:(UIView *)gridHeaderView
@@ -373,7 +373,7 @@ struct KKSectionMetrics {
     _gridHeaderView = gridHeaderView;
     
     [self addSubview:gridHeaderView];
-    [self setNeedsLayout];
+    [self _respondToBoundsChange];
 }
 
 #pragma mark - Batch Editing


### PR DESCRIPTION
When I set header or footer of gridview, My datasource maybe modified,so I need reload number of items in gridview 
